### PR TITLE
wtheo.tex: Fixed Kolmogorov-Criterion

### DIFF
--- a/wtheo.tex
+++ b/wtheo.tex
@@ -213,7 +213,7 @@
 		In diesem Fall $X=\E X_1 \fs{\P}$
 	\end{satz}
 	\begin{satz}[Kolmogorov-Kriterium]
-		$(X_n)$ unabhängig, $\forall n:\E X_n^2\leq \infty$, $\exists (a_n): \sum_{n=1}^\infty \frac{\V X_n}{a_n^2}\leq \infty$.
+		$(X_n)$ unabhängig, $\forall n:\E X_n^2<\infty$, $\exists (a_n): \sum_{n=1}^\infty \frac{\V X_n}{a_n^2}<\infty$.
 		Dann \[\frac{1}{a_n}\sum_{j=1}^n(X_j-\E X_j)\fsk 0.\]
 	\end{satz}
 	\begin{satz}[Gleichmäßig beschränkte Varianzen]


### PR DESCRIPTION
< instead of \leq